### PR TITLE
Log to stdout and specified file; Use pyserial instead of serial library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ __pycache__
 venv/
 *.log
 Logs
+.DS_Store
+build/
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Logs
 .DS_Store
 build/
 dist/
+main.spec

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ idna==2.10
 iso8601==0.1.12
 PyYAML==5.3.1
 requests==2.24.0
-serial==0.0.97
+pyserial==3.5
 timeout-decorator==0.4.1
 urllib3==1.25.10

--- a/src/main.py
+++ b/src/main.py
@@ -4,9 +4,12 @@ import logging
 import os
 import shutil
 import signal
+import sys
+
 from Components.Controller import Controller
 from Components.SerialConnection import SerialConnection
 from Components.MockSerialConnection import MockSerialConnection
+from sys import exit
 
 ### Get cmd line arguments from user ###
 
@@ -36,10 +39,17 @@ if not os.path.isdir(logging_dir):
     except FileExistsError:
         print("Directory ", logging_dir, " already exists")
 
-logging.basicConfig(filename=logging_dir + '/spencer_tcd' +
-                             datetime.datetime.now().isoformat() + '.log',
-                    level=logging.DEBUG,
-                    format='%(levelname)s:%(message)s')
+# Initialize logger
+LOGGER_FILENAME = logging_dir + '/spencer_tcd' + datetime.datetime.now().isoformat() + '.log'
+LOGGER_LEVEL = logging.DEBUG
+LOGGER_FORMAT = '%(levelname)s:%(message)s'
+
+file_handler = logging.FileHandler(filename=LOGGER_FILENAME)
+stdout_handler = logging.StreamHandler(sys.stdout)
+handlers = [file_handler, stdout_handler]
+logging.basicConfig(handlers=handlers, level=LOGGER_LEVEL, format=LOGGER_FORMAT)
+
+
 controller = None
 if args.mode == 'demo':
     MockSerialConnection.is_demo = True


### PR DESCRIPTION
# Summary
The `logging` library did not output to `stdout` which made it difficult to retrieve real-time logs in a Node process. Now, the logger is able to output to a file along with `stdout` making it easier for a Node process to pipe real-time logs programmatically (as a result, makes it easier to display logs on the UI).